### PR TITLE
Fix N+1 query issue in bulk lazy loader when expired objects are in session

### DIFF
--- a/lib/sqlalchemy_bulk_lazy_loader.py
+++ b/lib/sqlalchemy_bulk_lazy_loader.py
@@ -177,6 +177,30 @@ class BulkLazyLoader(LazyLoader):
         current_model = state.obj()
         # Find all models in this session that also need this same relationship to be populated
         similar_models = self._get_similar_unpopulated_models(current_model, session)
+
+        # Reload expired models
+        # If we don't reload them now, _get_model_value will refetch them one
+        # by one, producing the n+1 query we were using this loader to avoid
+        expired_similar_models = [m for m in similar_models if inspect(m).expired]
+        expired_model_keys = []
+        for model in expired_similar_models:
+            identity = inspect(model).identity
+            expired_model_keys.append(identity)
+        if len(expired_model_keys) > 0:
+            model_class = current_model.__class__
+            primary_key_cols = inspect(model_class).primary_key
+            # Only handle models where there is a single primary key column,
+            # for simplicity
+            if len(primary_key_cols) == 1:
+                primary_key_col = primary_key_cols[0]
+                # Querying them without doing anything with the result is
+                # enough to unexpire the models in similar_models
+                session.query(
+                    model_class
+                ).filter(
+                    primary_key_col.in_(expired_model_keys)
+                ).all()
+
         param_value_to_models = {}
         param_values = set()
         for model in similar_models:


### PR DESCRIPTION
Summary: While running a script I noticed it was causing the N+1 query warning to go off, even though I hadn't done anything that should have triggered that. Digging into that, it turned out that an interaction between the bulk lazy loader and SQLAlchemy was causing that to happen. This commit tries to modify the bulk lazy loader to avoid this issue.

A simple way of reproducing the issue is:
- fetch 10 people
- commit
- read people[0].phone_numbers (a relationship that uses `lazy="bulk"`)

You'll see that before the phone numbers are read, 10 `SELECT * FROM person WHERE id = #` queries are run! Fetching each of these models one-by-one is definitely not good for performance.

This is happening because the bulk lazy loader will look for similar models to `people[0]` in the session, and then tries to load the identifier on each model, which causes them to be refetched if they are expired.

There are a few possible ways we could deal with this: we could skip expired models, but I was hesitant to do that, since it seems like it would negate the benefit of this loader. We could change how it reads the primary key to avoid needing to refresh the model object, but then I think we'd still have an issue with serial queries when other code needs to read any properties on that object.

Instead, this looks at the similar models we found, checks if any of them are expired, and if they are, issues a query to refetch them, which is enough to unexpire the similar models, since they are in the same session.

I was a bit nervous that this would result in potentially fetching a large number of models, but I think I was able to rationalize that since it is just converting N queries that would have been issued one-by-one into a single query, which is objectively better. I think my concerns are more around the bulk lazy loader generally.

Test Plan: re-ran the script I had created to reproduce this issue, saw that now it only issued 1 of the SELECT queries for person, for 10 IDs.

I tried a few situations where a model had been deleted or added to the session, and this code still worked